### PR TITLE
Fix patching

### DIFF
--- a/pull
+++ b/pull
@@ -30,7 +30,7 @@ vendor() {
   # Patching
   if [ -d "$PATCHES/$1" ]
   then
-    for patch in "$2"/*.patch
+    for patch in "$PATCHES/$1"/*.patch
     do
       log "Patching $1: $patch"
       git -C "$4/$1" apply --3way "$patch"


### PR DESCRIPTION
When patching `googletest`, this was failing like this:

```sh
$ vendor/vendorpull/pull googletest
-- Setting up temporary directory at /var/folders/1s/mr6_sxdx0_59tj0xq5qzt_z00000gn/T/vendorpull-clone-XXXXX.eHmjZ9kH...
-- Fetching https://github.com/google/googletest@356fc301251378e0f6fa6aa794d73714202887ac into /var/folders/1s/mr6_sxdx0_59tj0xq5qzt_z00000gn/T/vendorpull-clone-XXXXX.eHmjZ9kH/googletest
Cloning into '/var/folders/1s/mr6_sxdx0_59tj0xq5qzt_z00000gn/T/vendorpull-clone-XXXXX.eHmjZ9kH/googletest'...
remote: Enumerating objects: 25311, done.
remote: Counting objects: 100% (15/15), done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 25311 (delta 2), reused 11 (delta 2), pack-reused 25296
Receiving objects: 100% (25311/25311), 11.30 MiB | 5.70 MiB/s, done.
Resolving deltas: 100% (18681/18681), done.
HEAD is now at 356fc301 Fix -Wshadow warnings
-- Patching googletest: https://github.com/google/googletest/*.patch
error: can't open patch 'https://github.com/google/googletest/*.patch': No such file or directory
```

and now it passes:

```sh
$ vendor/vendorpull/pull googletest
-- Setting up temporary directory at /var/folders/1s/mr6_sxdx0_59tj0xq5qzt_z00000gn/T/vendorpull-clone-XXXXX.0iMHYEB4...
-- Fetching https://github.com/google/googletest@356fc301251378e0f6fa6aa794d73714202887ac into /var/folders/1s/mr6_sxdx0_59tj0xq5qzt_z00000gn/T/vendorpull-clone-XXXXX.0iMHYEB4/googletest
Cloning into '/var/folders/1s/mr6_sxdx0_59tj0xq5qzt_z00000gn/T/vendorpull-clone-XXXXX.0iMHYEB4/googletest'...
remote: Enumerating objects: 25311, done.
remote: Counting objects: 100% (15/15), done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 25311 (delta 2), reused 11 (delta 2), pack-reused 25296
Receiving objects: 100% (25311/25311), 11.21 MiB | 12.53 MiB/s, done.
Resolving deltas: 100% (18685/18685), done.
HEAD is now at 356fc301 Fix -Wshadow warnings
-- Patching googletest: /Users/raisinten/Desktop/git/starship-next/patches/googletest/0001-Fix-Wdouble-promotion-compilation-warning.patch
Applied patch to 'CONTRIBUTORS' cleanly.
Applied patch to 'googletest/include/gtest/gtest-printers.h' cleanly.
-- Pruning /var/folders/1s/mr6_sxdx0_59tj0xq5qzt_z00000gn/T/vendorpull-clone-XXXXX.0iMHYEB4/googletest
-- Masking googletest: googletest/test
-- Masking googletest: googlemock/test
-- Masking googletest: docs
-- Masking googletest: ci
-- Moving /var/folders/1s/mr6_sxdx0_59tj0xq5qzt_z00000gn/T/vendorpull-clone-XXXXX.0iMHYEB4/googletest to /Users/raisinten/Desktop/git/starship-next/vendor/googletest
```

Signed-off-by: Darshan Sen <raisinten@gmail.com>